### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,8 @@ jobs:
   tests:
     name: Tests PHP ${{ matrix.php }}
     runs-on: ubuntu-latest
-    
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-seo/security/code-scanning/1](https://github.com/RumenDamyanov/php-seo/security/code-scanning/1)

To fix the problem, set an explicit `permissions` key for the job (or globally for the workflow) specifying the minimum required privileges for GITHUB_TOKEN, thus adhering to the principle of least privilege. For a typical CI workflow that checks out source code and runs tests, the minimal needed permission is usually `contents: read`. If there are steps requiring other permissions (such as uploading code coverage, opening issues/pull requests, etc.), those can be added as needed. In this specific workflow, all steps read repository contents, and one step uploads coverage via an external token (`secrets.CODECOV_TOKEN`), so `contents: read` is sufficient.

This change should be made within the `.github/workflows/ci.yml` file, on the job definition at `jobs.tests` (or at the top level for all jobs).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
