### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   style:
     name: Code Style Check
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-seo/security/code-scanning/5](https://github.com/RumenDamyanov/php-seo/security/code-scanning/5)

To remediate the issue, add a `permissions` block at the job or workflow level to restrict the `GITHUB_TOKEN` to minimal access. In this specific workflow, only read access to repository contents is required, as the job checks out code and installs dependencies but does not perform any write operations. The preferred fix is to add `permissions: contents: read` either at the job level (inside the `style:` job) or at the top-level (after the workflow name and triggers) if you want to apply it to all jobs. Since there is only one job here, either placement is effective, but job-level positioning is most localized and clear for future maintenance. No other changes or imports are needed.

Edit the block beginning with `name: Code Style Check` (line 11) and add the `permissions` key below it:

```yaml
name: Code Style Check
permissions:
  contents: read
```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
