### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/analyze.yml
+++ b/.github/workflows/analyze.yml
@@ -1,4 +1,6 @@
 name: Analyze
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-seo/security/code-scanning/4](https://github.com/RumenDamyanov/php-seo/security/code-scanning/4)

To fix this problem, you should add a `permissions` block to your workflow. Since the workflow only checks out code, sets up PHP, manages dependencies, and runs static analysis (all read-only operations), you do not need any write privileges. The recommended minimum is to grant `contents: read`—this suffices for checking out code and most actions that don't need to push, create PRs, or otherwise write to the repo.

You can add `permissions: contents: read` at the top level of the workflow (recommended, as it applies to all jobs), or to the `phpstan` job if different jobs require different permissions. In your case, since there’s only one job, adding it at the workflow root (after `name:` and before `on:`) is suitable.

No other code changes or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
